### PR TITLE
Added possibility to register a name for the Nats.Client

### DIFF
--- a/lib/nats/client.ex
+++ b/lib/nats/client.ex
@@ -22,11 +22,26 @@ defmodule Nats.Client do
                   opts: @default_opts,
                   next_sid: 0}
 
-  def start_link(opts \\ %{}) do
+  def start_link(opts \\ %{})
+  def start_link(opts) when is_map(opts) do
     GenServer.start_link(__MODULE__, Map.merge(@default_opts, opts))
   end
-  def start(opts \\ %{}) do
+  def start_link(name) do
+    start_link(name, %{})
+  end
+  def start_link(name, opts) do
+    GenServer.start_link(__MODULE__, Map.merge(@default_opts, opts), name: name)
+  end
+
+  def start(opts \\ %{})
+  def start(opts) when is_map(opts) do
     GenServer.start(__MODULE__, Map.merge(@default_opts, opts))
+  end
+  def start(name) do
+    start(name, %{})
+  end
+  def start(name, opts) when is_map(opts) do
+    GenServer.start(__MODULE__, Map.merge(@default_opts, opts), name: name)
   end
 
   def init(orig_opts) do

--- a/test/nats/client_test.exs
+++ b/test/nats/client_test.exs
@@ -46,6 +46,18 @@ defmodule Nats.ClientTest do
     :ok = Client.flush(con)
   end
 
+  test "Open a named client" do
+    subject = "FOO-bar"
+
+    {:ok, _ } = Client.start_link :test_client
+    {:ok, ref1} = Client.sub(:test_client, self(), subject)
+    :ok == Client.unsub(:test_client, ref1)
+
+    {:ok, _ } = Client.start :test_client2
+    {:ok, ref2} = Client.sub(:test_client2, self(), subject)
+    :ok == Client.unsub(:test_client2, ref2)
+  end
+
   test "Client wants tls vs. server doesn't" do
     opts = %{ tls_required: true, port: TestHelper.default_port, }
     {:error, _why } = Client.start opts


### PR DESCRIPTION
Hi, 
Added parameter name to Nats.Client.start and start_link to set a registered process name on the
started connection.