### PR TITLE
change version of earmark

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Nats.Mixfile do
   defp deps do
     [{:exrm, "~> 1.0", only: :dev},
      {:excoveralls, "~> 0.5", only: :test},
-     {:earmark, "~> 1.0", only: :dev},
+     {:earmark, "~> 1.2.3", only: :dev},
      {:ex_doc, "~> 0.12", only: :dev}]
   end
 


### PR DESCRIPTION
Please, change version of earmark for remove warnings:

==> earmark
Compiling 3 files (.erl)
Compiling 19 files (.ex)
warning: variable "all_converters" does not exist and is being expanded to "all_converters()", please use parentheses to remove the ambiguity or change the variable name
  lib/earmark/inline.ex:19

warning: variable "all_converters" does not exist and is being expanded to "all_converters()", please use parentheses to remove the ambiguity or change the variable name
  lib/earmark/inline.ex:54

warning: variable "all_converters" does not exist and is being expanded to "all_converters()", please use parentheses to remove the ambiguity or change the variable name
  lib/earmark/inline.ex:245

warning: module attribute @id_close_rgx was set but never used
  lib/earmark/scanner.ex:9
